### PR TITLE
fix: unmatched shortcuts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,10 @@ export function presetScrollbar(option?: PresetScrollbarDefaultOption): Preset {
         'scrollbar', [
           { overflow: 'auto' },
           'scrollbar-custom-property',
-          'scrollbar-width-auto',
-          `scrollbar-color-[var(${resolveVar('thumb')})_var(${resolveVar('track')})]`,
+          ...config.noCompatible ? [] : [
+            'scrollbar-width-auto',
+            `scrollbar-color-[var(${resolveVar('thumb')})_var(${resolveVar('track')})]`,
+          ],
           `scrollbar-track:scrollbar-background-color-[var(${resolveVar('track')})]`,
           `scrollbar-thumb:scrollbar-background-color-[var(${resolveVar('thumb')})]`,
           `scrollbar:scrollbar-width-[var(${resolveVar('width')})]`,
@@ -123,11 +125,11 @@ export function presetScrollbar(option?: PresetScrollbarDefaultOption): Preset {
         `,
       ],
       [
-        'scrollbar-thin', `
-          scrollbar-w-8px
-          scrollbar-h-8px
-          scrollbar-width-thin
-        `,
+        'scrollbar-thin', [ 
+          'scrollbar-w-8px',
+          'scrollbar-h-8px',
+          ...config.noCompatible ? [] : ['scrollbar-width-thin'],
+        ],
       ],
       [
         'scrollbar-none', `


### PR DESCRIPTION
**问题原因**：由于`noCompatible`为`true`时，`rules`内返回空对象，导致`shortcuts`内存在未匹配问题。
**解决方法**：直接在`shortcuts`中根据`noCompatible`进行判断，为`true`则返回空数组。